### PR TITLE
Add subsumption and skolem types

### DIFF
--- a/grimheart-ast/Type.mli
+++ b/grimheart-ast/Type.mli
@@ -4,6 +4,7 @@ type type_vars_t = Core_kernel.Set.M(Core_kernel.String).t
 type t =
   | Constructor of string
   | Variable of string
+  | Skolem of string * t option
   | Unsolved of string
   | Forall of string * t option * t
   | Apply of t * t

--- a/grimheart-core/type_checker/Context.ml
+++ b/grimheart-core/type_checker/Context.ml
@@ -14,10 +14,10 @@ module Element = struct
     | KindedUnsolved of string * Type.t
     | KindedSolved of string * Type.t * Type.t
     | Marker of string
-  [@@deriving eq]
+  [@@deriving eq, show]
 end
 
-type t = Element.t list
+type t = Element.t list [@@deriving eq, show]
 
 let rec apply (context : t) (t : Type.t) : Type.t =
   let open Type in

--- a/grimheart-core/type_checker/Context.ml
+++ b/grimheart-core/type_checker/Context.ml
@@ -24,6 +24,8 @@ let rec apply (context : t) (t : Type.t) : Type.t =
   match t with
   | Constructor _ -> t
   | Variable _ -> t
+  | Skolem (a, k) -> (
+      match k with Some k -> Skolem (a, Some (apply context k)) | None -> t)
   | Unsolved u ->
       let find_solved = function
         | (Element.Solved (u', t) | Element.KindedSolved (u', _, t))

--- a/grimheart-core/type_checker/Context.mli
+++ b/grimheart-core/type_checker/Context.mli
@@ -13,10 +13,20 @@ module Element : sig
     | Marker of string
 
   val equal : t -> t -> bool
+
+  val pp : Format.formatter -> t -> unit
+
+  val show : t -> string
 end
 
 (** The type of the context. *)
 type t = Element.t list
+
+val equal : t -> t -> bool
+
+val pp : Format.formatter -> t -> unit
+
+val show : t -> string
 
 val apply : t -> Type.t -> Type.t
 (** [apply context _T] applies a context to a type _T. This takes all unsolved

--- a/grimheart-core/type_checker/Kinds.mli
+++ b/grimheart-core/type_checker/Kinds.mli
@@ -30,6 +30,12 @@ val elaborate :
   -> Grimheart_ast.Type.t
   -> (Grimheart_ast.Type.t, Grimheart_core_errors.t) result
 
+val subsumes :
+     Context.t
+  -> Grimheart_ast.Type.t
+  -> Grimheart_ast.Type.t
+  -> (Context.t, Grimheart_core_errors.t) result
+
 val unify :
      Context.t
   -> Grimheart_ast.Type.t

--- a/grimheart-core/type_checker/Types.ml
+++ b/grimheart-core/type_checker/Types.ml
@@ -118,8 +118,8 @@ and unify (gamma : Context.t) (t1 : Type.t) (t2 : Type.t) :
       let* gamma = unify gamma a1 a2 in
       unify gamma b1 b2
   | KindApply (a1, b1), KindApply (a2, b2) ->
-      let* gamma = Kinds.unify gamma b1 b2 in
-      unify gamma a1 a2
+      let* gamma = Kinds.unify gamma a1 a2 in
+      unify gamma b1 b2
   | _U, Annotate (_T, _K) ->
       let* gamma, _ = Kinds.check gamma _U _K in
       unify gamma _U _T

--- a/grimheart-core/type_checker/Types.ml
+++ b/grimheart-core/type_checker/Types.ml
@@ -80,7 +80,6 @@ let rec subsumes (gamma : Context.t) (t1 : Type.t) (t2 : Type.t) :
 
 and unify (gamma : Context.t) (t1 : Type.t) (t2 : Type.t) :
     (Context.t, Grimheart_core_errors.t) result =
-  let open Type.Primitives in
   match (t1, t2) with
   | Constructor a, Constructor b when String.equal a b ->
       (* todo: perform environment checks here? *)
@@ -94,12 +93,6 @@ and unify (gamma : Context.t) (t1 : Type.t) (t2 : Type.t) :
   | Unsolved a, Unsolved b
     when String.equal a b && Context.mem gamma (Unsolved a) ->
       Ok gamma
-  (* function application is funky *)
-  | Apply (Apply (t_function1, a1), b1), Apply (Apply (t_function2, a2), b2)
-    when Type.equal t_function t_function1 && Type.equal t_function t_function2
-    ->
-      let* theta = unify gamma a2 a1 in
-      unify theta (Context.apply theta b1) (Context.apply theta b2)
   | Forall (a1, k1, t1), Forall (a2, k2, t2) ->
       let a' = fresh_name () in
       let t1 = Type.substitute a1 (Skolem (a', k1)) t1 in

--- a/grimheart-core/type_checker/Types.ml
+++ b/grimheart-core/type_checker/Types.ml
@@ -13,6 +13,11 @@ let rec well_formed_type (context : Context.t) (_T : Type.t) :
     (unit, Grimheart_core_errors.t) result =
   match _T with
   | Constructor _ -> Ok ()
+  | Skolem (v, k) -> (
+      match k with
+      | Some k when Context.mem context (KindedQuantified (v, k)) -> Ok ()
+      | None when Context.mem context (Quantified v) -> Ok ()
+      | _ -> Error (IllFormedType _T))
   | Variable v ->
       if Context.mem context (Quantified v)
       then Ok ()
@@ -128,6 +133,7 @@ and solve (gamma : Context.t) (a : string) (_B : Type.t) :
   match _B with
   | Constructor _ -> insertSolved _B
   | Variable _ -> insertSolved _B
+  | Skolem _ -> insertSolved _B
   | Unsolved b -> (
       match Context.break_apart_at_unsolved b gammaL with
       | Error _ -> insertSolved _B

--- a/grimheart-core/type_checker/Types.mli
+++ b/grimheart-core/type_checker/Types.mli
@@ -6,9 +6,13 @@ val well_formed_type :
     with respect to the context. This function is used to partially verify the
     correctness of the algorithmic context. *)
 
+val subsumes :
+  Context.t -> Type.t -> Type.t -> (Context.t, Grimheart_core_errors.t) result
+(** [subsumes t1 t2] subsumes t1 with t2. *)
+
 val unify :
   Context.t -> Type.t -> Type.t -> (Context.t, Grimheart_core_errors.t) result
-(** [subtype _A _B] unifies the type _A with _B. *)
+(** [unify t1 t2] unifies t1 with t2. *)
 
 val solve :
   Context.t -> string -> Type.t -> (Context.t, Grimheart_core_errors.t) result

--- a/tests/core/type_checker/type_checker.ml
+++ b/tests/core/type_checker/type_checker.ml
@@ -1,3 +1,4 @@
+open Core_kernel
 open Grimheart_ast
 open Grimheart_core_type_checker
 
@@ -8,29 +9,80 @@ module Test_utils = struct
       (testable Type.pp Type.equal)
       (testable Grimheart_core_errors.pp Grimheart_core_errors.equal)
 
-  let infer_type_check_test_case annotation speed expected value =
+  let testable_context_error =
+    let open Alcotest in
+    result
+      (testable Context.pp Context.equal)
+      (testable Grimheart_core_errors.pp Grimheart_core_errors.equal)
+
+  let infer_type_check_test_case annotation expected value =
     let check () =
       Alcotest.check testable_type_error annotation (Ok expected)
         (Types.infer_type value)
     in
-    Alcotest.test_case annotation speed check
+    Alcotest.test_case annotation `Quick check
+
+  let subsumes_test_case annotation t1 t2 =
+    let check () =
+      Alcotest.(check bool)
+        annotation true
+        (Result.is_ok @@ Types.subsumes [] t1 t2)
+    in
+    Alcotest.test_case annotation `Quick check
+
+  let subsumes_fail_case annotation t1 t2 =
+    let check () =
+      Alcotest.(check bool)
+        annotation false
+        (Result.is_ok @@ Types.subsumes [] t1 t2)
+    in
+    Alcotest.test_case annotation `Quick check
+
+  let unify_test_case annotation t1 t2 =
+    let check () =
+      Alcotest.(check bool)
+        annotation true
+        (Result.is_ok @@ Types.unify [Unsolved "A"; Unsolved "B"] t1 t2)
+    in
+    Alcotest.test_case annotation `Quick check
+
+  let unify_fail_case annotation t1 t2 =
+    let check () =
+      Alcotest.(check bool)
+        annotation false
+        (Result.is_ok @@ Types.unify [] t1 t2)
+    in
+    Alcotest.test_case annotation `Quick check
+
+  module Sweeter = struct
+    include Grimheart_ast.Type.Primitives
+    include Grimheart_ast.Type.Sugar
+
+    let forall a t = Type.Forall (a, None, t)
+
+    let forall' a k t = Type.Forall (a, Some k, t)
+
+    let var a = Type.Variable a
+
+    let uns a = Type.Unsolved a
+  end
 end
 
 let () =
   let open Alcotest in
   let open Test_utils in
-  let open Type.Primitives in
+  let open Test_utils.Sweeter in
   run "Core"
     [
       ( "infer-literal-scalar"
       , [
-          infer_type_check_test_case "infer char literal" `Quick t_char
+          infer_type_check_test_case "infer char literal" t_char
             (Expr.Literal (Char 'a'))
-        ; infer_type_check_test_case "infer string literal" `Quick t_string
+        ; infer_type_check_test_case "infer string literal" t_string
             (Expr.Literal (String "a"))
-        ; infer_type_check_test_case "infer int literal" `Quick t_int
+        ; infer_type_check_test_case "infer int literal" t_int
             (Expr.Literal (Int 0))
-        ; infer_type_check_test_case "infer float literal" `Quick t_float
+        ; infer_type_check_test_case "infer float literal" t_float
             (Expr.Literal (Float 0.))
         ] )
     ; ( "infer-literal-array-scalar"
@@ -38,24 +90,76 @@ let () =
           match t with
           | Type.Constructor t ->
               infer_type_check_test_case
-                (Printf.sprintf "infer array %s literal"
-                   (String.lowercase_ascii t))
-                `Quick
-                (Apply (t_array, Type.Constructor t))
+                (Printf.sprintf "infer array %s literal" (String.lowercase t))
+                (ap t_array (Type.Constructor t))
                 (Expr.Literal (Literal.Array [Expr.Literal l; Expr.Literal l]))
           | _ -> failwith "not a constructor"
         in
-        List.map make
+        List.map ~f:make
           [
-            (t_char, Char 'a')
-          ; (t_string, String "a")
-          ; (t_int, Int 0)
-          ; (t_float, Float 0.)
+            (t_char, Literal.Char 'a')
+          ; (t_string, Literal.String "a")
+          ; (t_int, Literal.Int 0)
+          ; (t_float, Literal.Float 0.)
           ] )
     ; ( "infer-literal-array-empty"
       , [
-          infer_type_check_test_case "infer empty array literal" `Quick
-            (Forall ("a", None, Apply (t_array, Variable "a")))
+          infer_type_check_test_case "infer empty array literal"
+            (forall "a" @@ ap t_array (var "a"))
             (Expr.Literal (Literal.Array []))
+        ] )
+    ; ( "subsumes-monotype"
+      , [
+          subsumes_test_case "monotype function subsumes with monotype function"
+            (fn t_int t_int) (fn t_int t_int)
+        ; subsumes_fail_case "monotype does not subsume polytype" t_int
+            (forall "a" @@ var "a")
+        ; subsumes_fail_case
+            "monotype function does not subsume with polytype function"
+            (fn t_int t_int)
+            (forall "a" @@ fn (var "a") (var "a"))
+        ] )
+    ; ( "subsumes-polytype"
+      , [
+          subsumes_test_case "polytype subsumes with polytype"
+            (forall "a" @@ var "a")
+            (forall "b" @@ var "b")
+        ; subsumes_test_case "polytype subsumes with monotype"
+            (forall "a" @@ var "a")
+            t_int
+        ; subsumes_test_case "polytype function subsumes with polytype function"
+            (forall "a" @@ forall "b" @@ fn (var "a") (var "b"))
+            (forall "c" @@ forall "d" @@ fn (var "c") (var "d"))
+        ; subsumes_test_case "polytype function subsumes with monotype function"
+            (forall "a" @@ fn (var "a") (var "a"))
+            (fn t_int t_int)
+        ; subsumes_test_case
+            "polytype subsumes with partially polytyped function"
+            (forall "a" @@ forall "b" @@ fn (var "a") (var "b"))
+            (forall "c" @@ fn (var "c") t_int)
+        ] )
+    ; ( "unify-polytype"
+      , [
+          unify_test_case "polytype unifies with polytype"
+            (forall "a" @@ var "a")
+            (forall "b" @@ var "b")
+        ; unify_fail_case "polytype does not unify with monotype"
+            (forall "a" @@ var "a")
+            t_int
+        ; unify_fail_case "monotypw does not unify with polytype" t_int
+            (forall "a" @@ var "a")
+        ] )
+    ; ( "unify-unsolved"
+      , [
+          unify_test_case "reflexive unsolved types unify" (uns "A") (uns "A")
+        ; unify_test_case "well-formed unsolved types unify" (uns "A") (uns "B")
+        ; unify_test_case "well-formed unsolved types unify flipped" (uns "B")
+            (uns "A")
+        ] )
+    ; ( "unify-application"
+      , [
+          unify_test_case "reflexive function application unifies"
+            (ap (fn t_int t_int) t_int)
+            (ap (fn t_int t_int) t_int)
         ] )
     ]


### PR DESCRIPTION
This adds subsumption to the type checker, as well as skolem types to both the type and kind checkers. This corrects the implementation of unification with foralls, while also allowing for higher-rank polymorphism.