### PR TITLE
Report skolem errors through well-formedness checks

### DIFF
--- a/grimheart-ast/Type.ml
+++ b/grimheart-ast/Type.ml
@@ -66,4 +66,12 @@ module Sugar = struct
   let k_ap a b = KindApply (a, b)
 
   let an a b = Annotate (a, b)
+
+  let forall a t = Forall (a, None, t)
+
+  let forall' a k t = Forall (a, Some k, t)
+
+  let var a = Variable a
+
+  let uns a = Unsolved a
 end

--- a/grimheart-ast/Type.mli
+++ b/grimheart-ast/Type.mli
@@ -62,4 +62,16 @@ module Sugar : sig
 
   val an : t -> t -> t
   (** Smart constructor for creating annotations. *)
+
+  val forall : string -> t -> t
+  (** Smart constructor for foralls. *)
+
+  val forall' : string -> t -> t -> t
+  (** Smart constructor for kinded foralls. *)
+
+  val var : string -> t
+  (** Smart constructor for variables. *)
+
+  val uns : string -> t
+  (** Smart constructor for unsolved variables. *)
 end

--- a/grimheart-core/errors/Grimheart_core_errors.ml
+++ b/grimheart-core/errors/Grimheart_core_errors.ml
@@ -11,6 +11,8 @@ type t =
   | CouldNotApplyKind of Type.t * Type.t * Type.t
   | InternalKindCheckerError of string
   | IllFormedType of Type.t
+  | EscapedSkolemVariable of Type.t
+  | VariableNotInScope of Type.t
   | UnknownVariable of string
   | FailedToBreakApart
   | RethrownError of t * t

--- a/grimheart-core/type_checker/Context.mli
+++ b/grimheart-core/type_checker/Context.mli
@@ -56,3 +56,8 @@ val break_apart_at_kinded_unsolved :
 
 val unsolved : t -> t
 (** [unsolved context] collects all unsolved elements in some context. *)
+
+val well_formed_type :
+  t -> Grimheart_ast.Type.t -> (unit, Grimheart_core_errors.t) result
+(** [well_formed_type context type_] asserts the well-formedness of the type
+    with respect to the current context. *)

--- a/grimheart-core/type_checker/Kinds.ml
+++ b/grimheart-core/type_checker/Kinds.ml
@@ -315,7 +315,10 @@ and promote (ctx : Context.t) (a : string) (t : Type.t) :
             :: theta
           in
           Ok (theta, Type.Unsolved b1))
-  | _ -> Ok (ctx, t)
+  | _ ->
+      let* ctxR, _, _ = Context.break_apart_at_kinded_unsolved a ctx in
+      let* _ = Context.well_formed_type ctxR t in
+      Ok (ctx, t)
 
 and unify_unsolved (ctx : Context.t) (a : string) (p1 : Type.t) :
     (Context.t, Grimheart_core_errors.t) result =

--- a/grimheart-core/type_checker/Types.ml
+++ b/grimheart-core/type_checker/Types.ml
@@ -9,40 +9,6 @@ let fresh_name : unit -> string =
     incr i;
     "t" ^ string_of_int !i
 
-let rec well_formed_type (context : Context.t) (_T : Type.t) :
-    (unit, Grimheart_core_errors.t) result =
-  match _T with
-  | Constructor _ -> Ok ()
-  | Skolem (v, _) ->
-     if Context.mem context (Quantified v)
-     then Ok ()
-     else Error (EscapedSkolemVariable _T)
-  | Variable v ->
-     if Context.mem context (Quantified v)
-     then Ok ()
-     else Error (VariableNotInScope _T)
-  | Unsolved u -> (
-      let predicate : Context.Element.t -> bool = function
-        | Unsolved u'
-        | KindedUnsolved (u', _)
-        | Solved (u', _)
-        | KindedSolved (u', _, _)
-          when String.equal u u' ->
-            true
-        | _ -> false
-      in
-      match List.find context ~f:predicate with
-      | Some _ -> Ok ()
-      | None -> Error (IllFormedType _T))
-  | Forall (a, k, _A) -> (
-      match k with
-      | Some k -> well_formed_type (KindedQuantified (a, k) :: context) _A
-      | None -> well_formed_type (Quantified a :: context) _A)
-  | Apply (_A, _B) | KindApply (_A, _B) | Annotate (_A, _B) ->
-      let* _ = well_formed_type context _A
-      and* _ = well_formed_type context _B in
-      Ok ()
-
 let scoped (context : Context.t) (element : Context.Element.t)
     (action : Context.t -> (Context.t, Grimheart_core_errors.t) result) :
     (Context.t, Grimheart_core_errors.t) result =
@@ -91,7 +57,7 @@ and unify (gamma : Context.t) (t1 : Type.t) (t2 : Type.t) :
   | (Skolem (a, _), Skolem (b, _) | Variable a, Variable b)
     when String.equal a b ->
       (* `a` must exist within the context *)
-      let* _ = well_formed_type gamma t1 in
+      let* _ = Context.well_formed_type gamma t1 in
       Ok gamma
   (* we only need these variables to be unsolved *)
   | Unsolved a, Unsolved b
@@ -139,7 +105,7 @@ and solve (gamma : Context.t) (a : string) (_B : Type.t) :
     Context.break_apart_at_unsolved a gamma
   in
   let insertSolved (t : Type.t) : (Context.t, Grimheart_core_errors.t) result =
-    let* _ = well_formed_type gammaR _B in
+    let* _ = Context.well_formed_type gammaR _B in
     Ok (List.append gammaL (Solved (a, t) :: gammaR))
   in
   match _B with

--- a/grimheart-core/type_checker/Types.ml
+++ b/grimheart-core/type_checker/Types.ml
@@ -13,10 +13,14 @@ let rec well_formed_type (context : Context.t) (_T : Type.t) :
     (unit, Grimheart_core_errors.t) result =
   match _T with
   | Constructor _ -> Ok ()
-  | Skolem (v, _) | Variable v ->
-      if Context.mem context (Quantified v)
-      then Ok ()
-      else Error (IllFormedType _T)
+  | Skolem (v, _) ->
+     if Context.mem context (Quantified v)
+     then Ok ()
+     else Error (EscapedSkolemVariable _T)
+  | Variable v ->
+     if Context.mem context (Quantified v)
+     then Ok ()
+     else Error (VariableNotInScope _T)
   | Unsolved u -> (
       let predicate : Context.Element.t -> bool = function
         | Unsolved u'

--- a/grimheart-core/type_checker/Types.mli
+++ b/grimheart-core/type_checker/Types.mli
@@ -1,11 +1,5 @@
 open Grimheart_ast
 
-val well_formed_type :
-  Context.t -> Type.t -> (unit, Grimheart_core_errors.t) result
-(** [well_formed_type context _T] determines the well-formedness of some type _T
-    with respect to the context. This function is used to partially verify the
-    correctness of the algorithmic context. *)
-
 val subsumes :
   Context.t -> Type.t -> Type.t -> (Context.t, Grimheart_core_errors.t) result
 (** [subsumes t1 t2] subsumes t1 with t2. *)


### PR DESCRIPTION
Closes #23. This adds two new errors `EscapedSkolemVariable` and `VariableNotInScope` to distinguish them between internal `IllFormedType` errors. Likewise, it also makes kind promotion perform well-formedness checks as it performs a similar role as instantiation/solving in the type checker.